### PR TITLE
breaking: replace generic integer types with fixed-width types

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A simple, header-only command line argument parser library for modern C++ (C++17
 ## Features
 
 - Header-only library for easy integration
-- Support for various argument types (string, integer, floating point, boolean flags)
+- Support for various argument types (string, fixed-width integers, floating point, boolean flags)
 - Required and optional arguments
 - Default values for arguments
 - Custom validators for arguments
@@ -38,8 +38,7 @@ int main(int argc, char* argv[]) {
     // Add an optional string argument with default value
     auto* outputFile = parser.addArgument<std::string>("output", "o", "Output file path", false, "output.txt");
     
-    // Add an optional integer argument with default value
-    auto* count = parser.addArgument<int>("count", "c", "Number of iterations", false, 1);
+    // Add an optional integer argument with default value\n    auto* count = parser.addArgument<int32_t>(\"count\", \"c\", \"Number of iterations\", false, 1);
     
     // Add floating point arguments
     auto* rate = parser.addArgument<float>("rate", "r", "Processing rate", false, 1.0f);
@@ -88,7 +87,7 @@ int main(int argc, char* argv[]) {
 
 ```cpp
 // Add a validator to ensure count is positive
-count->setValidator([](int value) { return value > 0; });
+count->setValidator([](int32_t value) { return value > 0; });
 
 // Add validators for floating point values
 rate->setValidator([](float value) { return value > 0.0f; });

--- a/examples/example.cpp
+++ b/examples/example.cpp
@@ -15,8 +15,8 @@ int main(int argc, char* argv[]) {
       parser.addArgument<std::string>("input", "i", "Input file path", true);
   auto* outputFile = parser.addArgument<std::string>(
       "output", "o", "Output file path", false, "output.txt");
-  auto* count =
-      parser.addArgument<int>("count", "c", "Number of iterations", false, 1);
+  auto* count = parser.addArgument<int32_t>("count", "c",
+                                            "Number of iterations", false, 1);
   auto* rate =
       parser.addArgument<float>("rate", "r", "Processing rate", false, 1.0f);
   auto* precision = parser.addArgument<double>(
@@ -29,7 +29,7 @@ int main(int argc, char* argv[]) {
       "dest", "Destination file", false);
 
   // Add validators
-  count->setValidator([](int value) { return value > 0; });
+  count->setValidator([](int32_t value) { return value > 0; });
   rate->setValidator([](float value) { return value > 0.0f; });
   precision->setValidator([](double value) { return value > 0.0; });
 

--- a/examples/integer_demo.cpp
+++ b/examples/integer_demo.cpp
@@ -7,18 +7,18 @@ int main(int argc, char* argv[]) {
                             "Demonstration of new integer argument types");
 
   // Add arguments for different integer types
-  auto* regular_int =
-      parser.addArgument<int>("int", "i", "Regular signed integer", false, 0);
-  auto* unsigned_int = parser.addArgument<unsigned int>(
-      "uint", "u", "Unsigned integer", false, 0u);
-  auto* long_int =
-      parser.addArgument<long>("long", "l", "Long signed integer", false, 0L);
-  auto* unsigned_long = parser.addArgument<unsigned long>(
+  auto* regular_int = parser.addArgument<int32_t>(
+      "int", "i", "Regular signed integer", false, 0);
+  auto* unsigned_int =
+      parser.addArgument<uint32_t>("uint", "u", "Unsigned integer", false, 0u);
+  auto* long_int = parser.addArgument<int64_t>(
+      "long", "l", "Long signed integer", false, 0L);
+  auto* unsigned_long = parser.addArgument<uint64_t>(
       "ulong", "g", "Unsigned long integer", false, 0UL);
 
   // Set validators to show range capabilities
-  unsigned_int->setValidator([](unsigned int value) { return value > 0; });
-  long_int->setValidator([](long value) { return value != 0; });
+  unsigned_int->setValidator([](uint32_t value) { return value > 0; });
+  long_int->setValidator([](int64_t value) { return value != 0; });
 
   auto result = parser.parse(argc, argv);
 
@@ -43,10 +43,12 @@ int main(int argc, char* argv[]) {
 
   std::cout << "\nType Ranges:\n";
   std::cout << "============\n";
-  std::cout << "int range: " << INT_MIN << " to " << INT_MAX << std::endl;
-  std::cout << "unsigned int range: 0 to " << UINT_MAX << std::endl;
-  std::cout << "long range: " << LONG_MIN << " to " << LONG_MAX << std::endl;
-  std::cout << "unsigned long range: 0 to " << ULONG_MAX << std::endl;
+  std::cout << "int32_t range: " << INT32_MIN << " to " << INT32_MAX
+            << std::endl;
+  std::cout << "uint32_t range: 0 to " << UINT32_MAX << std::endl;
+  std::cout << "int64_t range: " << INT64_MIN << " to " << INT64_MAX
+            << std::endl;
+  std::cout << "uint64_t range: 0 to " << UINT64_MAX << std::endl;
 
   return 0;
 }

--- a/include/argsparser.hpp
+++ b/include/argsparser.hpp
@@ -3,6 +3,7 @@
 
 #include <cerrno>   // For errno
 #include <climits>  // For INT_MAX and INT_MIN
+#include <cstdint>  // For fixed-width integer types
 #include <cstdio>   // For snprintf
 #include <cstdlib>  // For atoi
 #include <functional>
@@ -362,29 +363,29 @@ class Argument<bool> : public ArgumentBase {
 };
 
 /**
- * @brief Specialization for integer arguments
+ * @brief Specialization for 16-bit integer arguments
  *
- * This specialization handles integer arguments, which require
- * conversion from string to int during parsing.
+ * This specialization handles 16-bit integer arguments, which require
+ * conversion from string to int16_t during parsing.
  */
 template <>
-class Argument<int> : public ArgumentBase {
+class Argument<int16_t> : public ArgumentBase {
  public:
   /**
-   * @brief Validator function type for integer arguments
+   * @brief Validator function type for 16-bit integer arguments
    *
-   * A validator is a function that takes an integer value and returns
+   * A validator is a function that takes an int16_t value and returns
    * true if the value is valid, false otherwise.
    */
-  using Validator = std::function<bool(int)>;
+  using Validator = std::function<bool(int16_t)>;
 
  private:
-  int value_;
+  int16_t value_;
   Validator validator_;
 
  public:
   /**
-   * @brief Construct a new Argument object for integer values
+   * @brief Construct a new Argument object for 16-bit integer values
    *
    * @param name The long name of the argument (e.g., "count")
    * @param shortName The short name of the argument (e.g., "c")
@@ -394,7 +395,7 @@ class Argument<int> : public ArgumentBase {
    */
   Argument(const std::string& name, const std::string& shortName,
            const std::string& description, bool required = false,
-           int defaultValue = 0)
+           int16_t defaultValue = 0)
       : ArgumentBase(name, shortName, description, required),
         value_(defaultValue) {}
 
@@ -407,7 +408,7 @@ class Argument<int> : public ArgumentBase {
   void setValidator(const Validator& validator) { validator_ = validator; }
 
   /**
-   * @brief Parse a string value into an integer
+   * @brief Parse a string value into a 16-bit integer
    *
    * @param value The string value to parse
    * @return true if parsing and validation were successful, false otherwise
@@ -423,11 +424,11 @@ class Argument<int> : public ArgumentBase {
     }
 
     // Check for overflow/underflow
-    if (errno == ERANGE || parsedValue > INT_MAX || parsedValue < INT_MIN) {
+    if (errno == ERANGE || parsedValue > INT16_MAX || parsedValue < INT16_MIN) {
       return false;
     }
 
-    value_ = static_cast<int>(parsedValue);
+    value_ = static_cast<int16_t>(parsedValue);
 
     if (validator_ && !validator_(value_)) {
       return false;
@@ -440,16 +441,16 @@ class Argument<int> : public ArgumentBase {
   /**
    * @brief Get the parsed value of this argument
    *
-   * @return int The parsed value
+   * @return int16_t The parsed value
    */
-  int getValue() const { return value_; }
+  int16_t getValue() const { return value_; }
 
  protected:
   /**
    * @brief Get the type name for this argument (e.g., "(integer)", "(float)")
    * @return The type name or empty string if no type name should be displayed
    */
-  std::string getTypeName() const override { return "(integer)"; }
+  std::string getTypeName() const override { return "(16-bit integer)"; }
 
   /**
    * @brief Get the default value as a string
@@ -468,29 +469,29 @@ class Argument<int> : public ArgumentBase {
 };
 
 /**
- * @brief Specialization for unsigned integer arguments
+ * @brief Specialization for 32-bit unsigned integer arguments
  *
- * This specialization handles unsigned integer arguments, which require
- * conversion from string to unsigned int during parsing.
+ * This specialization handles 32-bit unsigned integer arguments, which require
+ * conversion from string to uint32_t during parsing.
  */
 template <>
-class Argument<unsigned int> : public ArgumentBase {
+class Argument<uint32_t> : public ArgumentBase {
  public:
   /**
-   * @brief Validator function type for unsigned integer arguments
+   * @brief Validator function type for 32-bit unsigned integer arguments
    *
-   * A validator is a function that takes an unsigned integer value and returns
+   * A validator is a function that takes a uint32_t value and returns
    * true if the value is valid, false otherwise.
    */
-  using Validator = std::function<bool(unsigned int)>;
+  using Validator = std::function<bool(uint32_t)>;
 
  private:
-  unsigned int value_;
+  uint32_t value_;
   Validator validator_;
 
  public:
   /**
-   * @brief Construct a new Argument object for unsigned integer values
+   * @brief Construct a new Argument object for 32-bit unsigned integer values
    *
    * @param name The long name of the argument (e.g., "count")
    * @param shortName The short name of the argument (e.g., "c")
@@ -500,7 +501,7 @@ class Argument<unsigned int> : public ArgumentBase {
    */
   Argument(const std::string& name, const std::string& shortName,
            const std::string& description, bool required = false,
-           unsigned int defaultValue = 0)
+           uint32_t defaultValue = 0)
       : ArgumentBase(name, shortName, description, required),
         value_(defaultValue) {}
 
@@ -513,7 +514,7 @@ class Argument<unsigned int> : public ArgumentBase {
   void setValidator(const Validator& validator) { validator_ = validator; }
 
   /**
-   * @brief Parse a string value into an unsigned integer
+   * @brief Parse a string value into a 32-bit unsigned integer
    *
    * @param value The string value to parse
    * @return true if parsing and validation were successful, false otherwise
@@ -531,7 +532,7 @@ class Argument<unsigned int> : public ArgumentBase {
     }
 
     // Check for overflow or negative values (strtoul would wrap negatives)
-    if (errno == ERANGE || parsedValue > UINT_MAX) {
+    if (errno == ERANGE || parsedValue > UINT32_MAX) {
       return false;
     }
 
@@ -540,7 +541,7 @@ class Argument<unsigned int> : public ArgumentBase {
       return false;
     }
 
-    value_ = static_cast<unsigned int>(parsedValue);
+    value_ = static_cast<uint32_t>(parsedValue);
 
     if (validator_ && !validator_(value_)) {
       return false;
@@ -553,16 +554,18 @@ class Argument<unsigned int> : public ArgumentBase {
   /**
    * @brief Get the parsed value of this argument
    *
-   * @return unsigned int The parsed value
+   * @return uint32_t The parsed value
    */
-  unsigned int getValue() const { return value_; }
+  uint32_t getValue() const { return value_; }
 
  protected:
   /**
    * @brief Get the type name for this argument (e.g., "(integer)", "(float)")
    * @return The type name or empty string if no type name should be displayed
    */
-  std::string getTypeName() const override { return "(unsigned integer)"; }
+  std::string getTypeName() const override {
+    return "(32-bit unsigned integer)";
+  }
 
   /**
    * @brief Get the default value as a string
@@ -581,29 +584,29 @@ class Argument<unsigned int> : public ArgumentBase {
 };
 
 /**
- * @brief Specialization for long integer arguments
+ * @brief Specialization for 32-bit integer arguments
  *
- * This specialization handles long integer arguments, which require
- * conversion from string to long during parsing.
+ * This specialization handles 32-bit integer arguments, which require
+ * conversion from string to int32_t during parsing.
  */
 template <>
-class Argument<long> : public ArgumentBase {
+class Argument<int32_t> : public ArgumentBase {
  public:
   /**
-   * @brief Validator function type for long integer arguments
+   * @brief Validator function type for 32-bit integer arguments
    *
-   * A validator is a function that takes a long integer value and returns
+   * A validator is a function that takes an int32_t value and returns
    * true if the value is valid, false otherwise.
    */
-  using Validator = std::function<bool(long)>;
+  using Validator = std::function<bool(int32_t)>;
 
  private:
-  long value_;
+  int32_t value_;
   Validator validator_;
 
  public:
   /**
-   * @brief Construct a new Argument object for long integer values
+   * @brief Construct a new Argument object for 32-bit integer values
    *
    * @param name The long name of the argument (e.g., "count")
    * @param shortName The short name of the argument (e.g., "c")
@@ -613,7 +616,7 @@ class Argument<long> : public ArgumentBase {
    */
   Argument(const std::string& name, const std::string& shortName,
            const std::string& description, bool required = false,
-           long defaultValue = 0)
+           int32_t defaultValue = 0)
       : ArgumentBase(name, shortName, description, required),
         value_(defaultValue) {}
 
@@ -626,7 +629,7 @@ class Argument<long> : public ArgumentBase {
   void setValidator(const Validator& validator) { validator_ = validator; }
 
   /**
-   * @brief Parse a string value into a long integer
+   * @brief Parse a string value into a 32-bit integer
    *
    * @param value The string value to parse
    * @return true if parsing and validation were successful, false otherwise
@@ -642,11 +645,11 @@ class Argument<long> : public ArgumentBase {
     }
 
     // Check for overflow/underflow
-    if (errno == ERANGE) {
+    if (errno == ERANGE || parsedValue > INT32_MAX || parsedValue < INT32_MIN) {
       return false;
     }
 
-    value_ = parsedValue;
+    value_ = static_cast<int32_t>(parsedValue);
 
     if (validator_ && !validator_(value_)) {
       return false;
@@ -659,16 +662,16 @@ class Argument<long> : public ArgumentBase {
   /**
    * @brief Get the parsed value of this argument
    *
-   * @return long The parsed value
+   * @return int32_t The parsed value
    */
-  long getValue() const { return value_; }
+  int32_t getValue() const { return value_; }
 
  protected:
   /**
    * @brief Get the type name for this argument (e.g., "(integer)", "(float)")
    * @return The type name or empty string if no type name should be displayed
    */
-  std::string getTypeName() const override { return "(long integer)"; }
+  std::string getTypeName() const override { return "(32-bit integer)"; }
 
   /**
    * @brief Get the default value as a string
@@ -687,29 +690,29 @@ class Argument<long> : public ArgumentBase {
 };
 
 /**
- * @brief Specialization for unsigned long integer arguments
+ * @brief Specialization for 64-bit unsigned integer arguments
  *
- * This specialization handles unsigned long integer arguments, which require
- * conversion from string to unsigned long during parsing.
+ * This specialization handles 64-bit unsigned integer arguments, which require
+ * conversion from string to uint64_t during parsing.
  */
 template <>
-class Argument<unsigned long> : public ArgumentBase {
+class Argument<uint64_t> : public ArgumentBase {
  public:
   /**
-   * @brief Validator function type for unsigned long integer arguments
+   * @brief Validator function type for 64-bit unsigned integer arguments
    *
-   * A validator is a function that takes an unsigned long integer value and
-   * returns true if the value is valid, false otherwise.
+   * A validator is a function that takes a uint64_t value and returns
+   * true if the value is valid, false otherwise.
    */
-  using Validator = std::function<bool(unsigned long)>;
+  using Validator = std::function<bool(uint64_t)>;
 
  private:
-  unsigned long value_;
+  uint64_t value_;
   Validator validator_;
 
  public:
   /**
-   * @brief Construct a new Argument object for unsigned long integer values
+   * @brief Construct a new Argument object for 64-bit unsigned integer values
    *
    * @param name The long name of the argument (e.g., "count")
    * @param shortName The short name of the argument (e.g., "c")
@@ -719,7 +722,7 @@ class Argument<unsigned long> : public ArgumentBase {
    */
   Argument(const std::string& name, const std::string& shortName,
            const std::string& description, bool required = false,
-           unsigned long defaultValue = 0)
+           uint64_t defaultValue = 0)
       : ArgumentBase(name, shortName, description, required),
         value_(defaultValue) {}
 
@@ -732,7 +735,7 @@ class Argument<unsigned long> : public ArgumentBase {
   void setValidator(const Validator& validator) { validator_ = validator; }
 
   /**
-   * @brief Parse a string value into an unsigned long integer
+   * @brief Parse a string value into a 64-bit unsigned integer
    *
    * @param value The string value to parse
    * @return true if parsing and validation were successful, false otherwise
@@ -741,16 +744,16 @@ class Argument<unsigned long> : public ArgumentBase {
    */
   bool parse(const std::string& value) override {
     char* end;
-    errno = 0;  // Reset errno before calling strtoul
-    unsigned long parsedValue = std::strtoul(value.c_str(), &end, 10);
+    errno = 0;  // Reset errno before calling strtoull
+    unsigned long long parsedValue = std::strtoull(value.c_str(), &end, 10);
 
     // Check if the entire string was consumed
     if (*end != '\0') {
       return false;
     }
 
-    // Check for overflow
-    if (errno == ERANGE) {
+    // Check for overflow or negative values (strtoull would wrap negatives)
+    if (errno == ERANGE || parsedValue > UINT64_MAX) {
       return false;
     }
 
@@ -759,7 +762,7 @@ class Argument<unsigned long> : public ArgumentBase {
       return false;
     }
 
-    value_ = parsedValue;
+    value_ = static_cast<uint64_t>(parsedValue);
 
     if (validator_ && !validator_(value_)) {
       return false;
@@ -772,16 +775,18 @@ class Argument<unsigned long> : public ArgumentBase {
   /**
    * @brief Get the parsed value of this argument
    *
-   * @return unsigned long The parsed value
+   * @return uint64_t The parsed value
    */
-  unsigned long getValue() const { return value_; }
+  uint64_t getValue() const { return value_; }
 
  protected:
   /**
    * @brief Get the type name for this argument (e.g., "(integer)", "(float)")
    * @return The type name or empty string if no type name should be displayed
    */
-  std::string getTypeName() const override { return "(unsigned long integer)"; }
+  std::string getTypeName() const override {
+    return "(64-bit unsigned integer)";
+  }
 
   /**
    * @brief Get the default value as a string
@@ -800,16 +805,123 @@ class Argument<unsigned long> : public ArgumentBase {
 };
 
 /**
- * @brief Specialization for float arguments
+ * @brief Specialization for 64-bit integer arguments
  *
- * This specialization handles float arguments, which require
- * conversion from string to float during parsing.
+ * This specialization handles 64-bit integer arguments, which require
+ * conversion from string to int64_t during parsing.
+ */
+template <>
+class Argument<int64_t> : public ArgumentBase {
+ public:
+  /**
+   * @brief Validator function type for 64-bit integer arguments
+   *
+   * A validator is a function that takes an int64_t value and returns
+   * true if the value is valid, false otherwise.
+   */
+  using Validator = std::function<bool(int64_t)>;
+
+ private:
+  int64_t value_;
+  Validator validator_;
+
+ public:
+  /**
+   * @brief Construct a new Argument object for 64-bit integer values
+   *
+   * @param name The long name of the argument (e.g., "count")
+   * @param shortName The short name of the argument (e.g., "c")
+   * @param description A description of the argument for help text
+   * @param required Whether this argument is required (default: false)
+   * @param defaultValue The default value for this argument (default: 0)
+   */
+  Argument(const std::string& name, const std::string& shortName,
+           const std::string& description, bool required = false,
+           int64_t defaultValue = 0)
+      : ArgumentBase(name, shortName, description, required),
+        value_(defaultValue) {}
+
+  /**
+   * @brief Set a validator function for this argument
+   *
+   * The validator function will be called during parsing to validate the value.
+   * @param validator The validator function to use
+   */
+  void setValidator(const Validator& validator) { validator_ = validator; }
+
+  /**
+   * @brief Parse a string value into a 64-bit integer
+   *
+   * @param value The string value to parse
+   * @return true if parsing and validation were successful, false otherwise
+   */
+  bool parse(const std::string& value) override {
+    char* end;
+    errno = 0;  // Reset errno before calling strtoll
+    long long parsedValue = std::strtoll(value.c_str(), &end, 10);
+
+    // Check if the entire string was consumed
+    if (*end != '\0') {
+      return false;
+    }
+
+    // Check for overflow/underflow
+    if (errno == ERANGE || parsedValue > INT64_MAX || parsedValue < INT64_MIN) {
+      return false;
+    }
+
+    value_ = static_cast<int64_t>(parsedValue);
+
+    if (validator_ && !validator_(value_)) {
+      return false;
+    }
+
+    isSet_ = true;
+    return true;
+  }
+
+  /**
+   * @brief Get the parsed value of this argument
+   *
+   * @return int64_t The parsed value
+   */
+  int64_t getValue() const { return value_; }
+
+ protected:
+  /**
+   * @brief Get the type name for this argument (e.g., "(integer)", "(float)")
+   * @return The type name or empty string if no type name should be displayed
+   */
+  std::string getTypeName() const override { return "(64-bit integer)"; }
+
+  /**
+   * @brief Get the default value as a string
+   * @return String representation of the default value or empty string if no
+   * default
+   */
+  std::string getDefaultString() const override {
+    return std::to_string(value_);
+  }
+
+  /**
+   * @brief Check if the argument has a default value that should be displayed
+   * @return true if a default value should be shown, false otherwise
+   */
+  bool hasDefaultValue() const override { return value_ != 0; }
+};
+
+/**
+ * @brief Specialization for single-precision floating-point arguments
+ *
+ * This specialization handles single-precision floating-point arguments, which
+ * require conversion from string to float during parsing.
  */
 template <>
 class Argument<float> : public ArgumentBase {
  public:
   /**
-   * @brief Validator function type for float arguments
+   * @brief Validator function type for single-precision floating-point
+   * arguments
    *
    * A validator is a function that takes a float value and returns
    * true if the value is valid, false otherwise.
@@ -822,7 +934,8 @@ class Argument<float> : public ArgumentBase {
 
  public:
   /**
-   * @brief Construct a new Argument object for float values
+   * @brief Construct a new Argument object for single-precision floating-point
+   * values
    *
    * @param name The long name of the argument (e.g., "rate")
    * @param shortName The short name of the argument (e.g., "r")
@@ -845,7 +958,7 @@ class Argument<float> : public ArgumentBase {
   void setValidator(const Validator& validator) { validator_ = validator; }
 
   /**
-   * @brief Parse a string value into a float
+   * @brief Parse a string value into a single-precision floating-point number
    *
    * @param value The string value to parse
    * @return true if parsing and validation were successful, false otherwise
@@ -921,16 +1034,17 @@ class Argument<float> : public ArgumentBase {
 };
 
 /**
- * @brief Specialization for double arguments
+ * @brief Specialization for double-precision floating-point arguments
  *
- * This specialization handles double arguments, which require
- * conversion from string to double during parsing.
+ * This specialization handles double-precision floating-point arguments, which
+ * require conversion from string to double during parsing.
  */
 template <>
 class Argument<double> : public ArgumentBase {
  public:
   /**
-   * @brief Validator function type for double arguments
+   * @brief Validator function type for double-precision floating-point
+   * arguments
    *
    * A validator is a function that takes a double value and returns
    * true if the value is valid, false otherwise.
@@ -943,7 +1057,8 @@ class Argument<double> : public ArgumentBase {
 
  public:
   /**
-   * @brief Construct a new Argument object for double values
+   * @brief Construct a new Argument object for double-precision floating-point
+   * values
    *
    * @param name The long name of the argument (e.g., "precision")
    * @param shortName The short name of the argument (e.g., "p")
@@ -966,7 +1081,7 @@ class Argument<double> : public ArgumentBase {
   void setValidator(const Validator& validator) { validator_ = validator; }
 
   /**
-   * @brief Parse a string value into a double
+   * @brief Parse a string value into a double-precision floating-point number
    *
    * @param value The string value to parse
    * @return true if parsing and validation were successful, false otherwise

--- a/include/argsparser.hpp
+++ b/include/argsparser.hpp
@@ -866,7 +866,7 @@ class Argument<int64_t> : public ArgumentBase {
     }
 
     // Check for overflow/underflow
-    if (errno == ERANGE) {
+    if (errno == ERANGE || parsedValue > INT64_MAX || parsedValue < INT64_MIN) {
       return false;
     }
 

--- a/include/argsparser.hpp
+++ b/include/argsparser.hpp
@@ -866,7 +866,7 @@ class Argument<int64_t> : public ArgumentBase {
     }
 
     // Check for overflow/underflow
-    if (errno == ERANGE || parsedValue > INT64_MAX || parsedValue < INT64_MIN) {
+    if (errno == ERANGE) {
       return false;
     }
 

--- a/tests/test_argsparser.cpp
+++ b/tests/test_argsparser.cpp
@@ -11,8 +11,8 @@ void test_basic_parsing() {
       "verbose", "v", "Enable verbose output", false, false);
   auto* inputFile =
       parser.addArgument<std::string>("input", "i", "Input file path", true);
-  auto* count =
-      parser.addArgument<int>("count", "c", "Number of iterations", false, 10);
+  auto* count = parser.addArgument<int32_t>("count", "c",
+                                            "Number of iterations", false, 10);
 
   const char* argv[] = {"test_app", "--input", "test.txt", "-v", "-c", "5"};
   int argc = sizeof(argv) / sizeof(argv[0]);
@@ -60,7 +60,8 @@ void test_missing_value() {
 
 void test_invalid_value() {
   argsparser::Parser parser("test_app", "A test application");
-  auto* count = parser.addArgument<int>("count", "c", "Number of iterations");
+  auto* count =
+      parser.addArgument<int32_t>("count", "c", "Number of iterations");
 
   const char* argv[] = {"test_app", "--count", "not_a_number"};
   int argc = sizeof(argv) / sizeof(argv[0]);
@@ -75,9 +76,9 @@ void test_invalid_value() {
 
 void test_validator() {
   argsparser::Parser parser("test_app", "A test application");
-  auto* count = parser.addArgument<int>(
+  auto* count = parser.addArgument<int32_t>(
       "count", "c", "Number of iterations (must be positive)");
-  count->setValidator([](int value) { return value > 0; });
+  count->setValidator([](int32_t value) { return value > 0; });
 
   const char* argv[] = {"test_app", "--count", "-5"};
   int argc = sizeof(argv) / sizeof(argv[0]);
@@ -93,7 +94,7 @@ void test_print_help() {
   parser.addArgument<bool>("verbose", "v", "Enable verbose output");
   parser.addArgument<std::string>("input", "i", "Input file path", true,
                                   "default.txt");
-  parser.addArgument<int>("count", "c", "Number of iterations", false, 10);
+  parser.addArgument<int32_t>("count", "c", "Number of iterations", false, 10);
 
   std::ostringstream oss;
   parser.printHelp(oss);
@@ -139,8 +140,8 @@ void test_equals_syntax() {
   argsparser::Parser parser("test_app", "A test application");
   auto* inputFile =
       parser.addArgument<std::string>("input", "i", "Input file path", true);
-  auto* count =
-      parser.addArgument<int>("count", "c", "Number of iterations", false, 10);
+  auto* count = parser.addArgument<int32_t>("count", "c",
+                                            "Number of iterations", false, 10);
 
   const char* argv[] = {"test_app", "--input=test.txt", "--count=5"};
   int argc = sizeof(argv) / sizeof(argv[0]);
@@ -163,8 +164,8 @@ void test_positional_arguments() {
       parser.addPositionalArgument<std::string>("input", "Input file path");
   auto* outputFile = parser.addPositionalArgument<std::string>(
       "output", "Output file path", false, "default.out");
-  auto* count =
-      parser.addArgument<int>("count", "c", "Number of iterations", false, 10);
+  auto* count = parser.addArgument<int32_t>("count", "c",
+                                            "Number of iterations", false, 10);
 
   const char* argv[] = {"test_app", "input.txt", "output.txt", "--count=5"};
   int argc = sizeof(argv) / sizeof(argv[0]);
@@ -244,7 +245,8 @@ void test_grouped_short_options_with_non_bool() {
   argsparser::Parser parser("test_app", "A test application");
   auto* verbose =
       parser.addArgument<bool>("verbose", "v", "Enable verbose output");
-  auto* count = parser.addArgument<int>("count", "c", "Number of iterations");
+  auto* count =
+      parser.addArgument<int32_t>("count", "c", "Number of iterations");
   auto* inputFile =
       parser.addArgument<std::string>("input", "i", "Input file path", true);
 

--- a/tests/test_integer_types.cpp
+++ b/tests/test_integer_types.cpp
@@ -5,13 +5,12 @@
 
 #include "argsparser.hpp"
 
-void test_unsigned_int_parsing() {
+void test_uint32_parsing() {
   argsparser::Parser parser("test_app", "A test application");
 
   auto* count =
-      parser.addArgument<unsigned int>("count", "c", "Count value", false, 10u);
-  auto* size =
-      parser.addArgument<unsigned int>("size", "s", "Size value", true);
+      parser.addArgument<uint32_t>("count", "c", "Count value", false, 10u);
+  auto* size = parser.addArgument<uint32_t>("size", "s", "Size value", true);
 
   const char* argv[] = {"test_app", "--count", "42", "--size", "100"};
   int argc = sizeof(argv) / sizeof(argv[0]);
@@ -25,13 +24,13 @@ void test_unsigned_int_parsing() {
   assert(count->getValue() == 42u);
   assert(size->getValue() == 100u);
 
-  std::cout << "test_unsigned_int_parsing passed\n";
+  std::cout << "test_uint32_parsing passed\n";
 }
 
-void test_unsigned_int_negative_values() {
+void test_uint32_negative_values() {
   argsparser::Parser parser("test_app", "A test application");
 
-  auto* count = parser.addArgument<unsigned int>("count", "c", "Count value");
+  auto* count = parser.addArgument<uint32_t>("count", "c", "Count value");
 
   const char* argv[] = {"test_app", "--count", "-5"};
   int argc = sizeof(argv) / sizeof(argv[0]);
@@ -39,51 +38,51 @@ void test_unsigned_int_negative_values() {
   auto result = parser.parse(argc, const_cast<char**>(argv));
   assert(result == argsparser::ParseResult::INVALID_VALUE);
 
-  std::cout << "test_unsigned_int_negative_values passed\n";
+  std::cout << "test_uint32_negative_values passed\n";
 }
 
-void test_unsigned_int_overflow() {
+void test_uint32_overflow() {
   argsparser::Parser parser("test_app", "A test application");
 
   auto* largeNumber =
-      parser.addArgument<unsigned int>("large", "l", "A large number");
+      parser.addArgument<uint32_t>("large", "l", "A large number");
 
-  // Test with a number that's too large for unsigned int
+  // Test with a number that's too large for uint32_t
   std::string largeValue =
-      std::to_string(static_cast<unsigned long long>(UINT_MAX) + 1);
+      std::to_string(static_cast<unsigned long long>(UINT32_MAX) + 1);
   const char* argv[] = {"test_app", "--large", largeValue.c_str()};
   int argc = sizeof(argv) / sizeof(argv[0]);
 
   auto result = parser.parse(argc, const_cast<char**>(argv));
   assert(result == argsparser::ParseResult::INVALID_VALUE);
 
-  std::cout << "test_unsigned_int_overflow passed\n";
+  std::cout << "test_uint32_overflow passed\n";
 }
 
-void test_unsigned_int_max() {
+void test_uint32_max() {
   argsparser::Parser parser("test_app", "A test application");
 
-  auto* maxNumber = parser.addArgument<unsigned int>(
-      "max", "m", "Maximum unsigned int value");
+  auto* maxNumber =
+      parser.addArgument<uint32_t>("max", "m", "Maximum uint32_t value");
 
-  // Test with UINT_MAX, which should work
-  std::string maxValue = std::to_string(UINT_MAX);
+  // Test with UINT32_MAX, which should work
+  std::string maxValue = std::to_string(UINT32_MAX);
   const char* argv[] = {"test_app", "--max", maxValue.c_str()};
   int argc = sizeof(argv) / sizeof(argv[0]);
 
   auto result = parser.parse(argc, const_cast<char**>(argv));
   assert(result == argsparser::ParseResult::SUCCESS);
-  assert(maxNumber->getValue() == UINT_MAX);
+  assert(maxNumber->getValue() == UINT32_MAX);
 
-  std::cout << "test_unsigned_int_max passed\n";
+  std::cout << "test_uint32_max passed\n";
 }
 
-void test_long_parsing() {
+void test_int64_parsing() {
   argsparser::Parser parser("test_app", "A test application");
 
   auto* count =
-      parser.addArgument<long>("count", "c", "Count value", false, 10L);
-  auto* size = parser.addArgument<long>("size", "s", "Size value", true);
+      parser.addArgument<int64_t>("count", "c", "Count value", false, 10L);
+  auto* size = parser.addArgument<int64_t>("size", "s", "Size value", true);
 
   const char* argv[] = {"test_app", "--count", "42", "--size", "-100"};
   int argc = sizeof(argv) / sizeof(argv[0]);
@@ -97,71 +96,74 @@ void test_long_parsing() {
   assert(count->getValue() == 42L);
   assert(size->getValue() == -100L);
 
-  std::cout << "test_long_parsing passed\n";
+  std::cout << "test_int64_parsing passed\n";
 }
 
-void test_long_overflow() {
+void test_int64_overflow() {
   argsparser::Parser parser("test_app", "A test application");
 
-  auto* largeNumber = parser.addArgument<long>("large", "l", "A large number");
+  auto* largeNumber =
+      parser.addArgument<int64_t>("large", "l", "A large number");
 
-  // Create a number larger than LONG_MAX
+  // Create a number larger than INT64_MAX
   std::string largeValue =
-      std::to_string(LONG_MAX) + "0";  // Add a digit to make it larger
+      std::to_string(INT64_MAX) + "0";  // Add a digit to make it larger
   const char* argv[] = {"test_app", "--large", largeValue.c_str()};
   int argc = sizeof(argv) / sizeof(argv[0]);
 
   auto result = parser.parse(argc, const_cast<char**>(argv));
   assert(result == argsparser::ParseResult::INVALID_VALUE);
 
-  std::cout << "test_long_overflow passed\n";
+  std::cout << "test_int64_overflow passed\n";
 }
 
-void test_long_underflow() {
+void test_int64_underflow() {
   argsparser::Parser parser("test_app", "A test application");
 
-  auto* smallNumber = parser.addArgument<long>("small", "s", "A small number");
+  auto* smallNumber =
+      parser.addArgument<int64_t>("small", "s", "A small number");
 
-  // Create a number smaller than LONG_MIN
+  // Create a number smaller than INT64_MIN
   std::string smallValue =
-      std::to_string(LONG_MIN) + "0";  // Add a digit to make it smaller
+      std::to_string(INT64_MIN) + "0";  // Add a digit to make it smaller
   const char* argv[] = {"test_app", "--small", smallValue.c_str()};
   int argc = sizeof(argv) / sizeof(argv[0]);
 
   auto result = parser.parse(argc, const_cast<char**>(argv));
   assert(result == argsparser::ParseResult::INVALID_VALUE);
 
-  std::cout << "test_long_underflow passed\n";
+  std::cout << "test_int64_underflow passed\n";
 }
 
-void test_long_max_min() {
+void test_int64_max_min() {
   argsparser::Parser parser("test_app", "A test application");
 
-  auto* maxNumber = parser.addArgument<long>("max", "m", "Maximum long value");
-  auto* minNumber = parser.addArgument<long>("min", "n", "Minimum long value");
+  auto* maxNumber =
+      parser.addArgument<int64_t>("max", "m", "Maximum int64_t value");
+  auto* minNumber =
+      parser.addArgument<int64_t>("min", "n", "Minimum int64_t value");
 
-  // Test with LONG_MAX and LONG_MIN, which should work
-  std::string maxValue = std::to_string(LONG_MAX);
-  std::string minValue = std::to_string(LONG_MIN);
+  // Test with INT64_MAX and INT64_MIN, which should work
+  std::string maxValue = std::to_string(INT64_MAX);
+  std::string minValue = std::to_string(INT64_MIN);
   const char* argv[] = {"test_app", "--max", maxValue.c_str(), "--min",
                         minValue.c_str()};
   int argc = sizeof(argv) / sizeof(argv[0]);
 
   auto result = parser.parse(argc, const_cast<char**>(argv));
   assert(result == argsparser::ParseResult::SUCCESS);
-  assert(maxNumber->getValue() == LONG_MAX);
-  assert(minNumber->getValue() == LONG_MIN);
+  assert(maxNumber->getValue() == INT64_MAX);
+  assert(minNumber->getValue() == INT64_MIN);
 
-  std::cout << "test_long_max_min passed\n";
+  std::cout << "test_int64_max_min passed\n";
 }
 
-void test_unsigned_long_parsing() {
+void test_uint64_parsing() {
   argsparser::Parser parser("test_app", "A test application");
 
-  auto* count = parser.addArgument<unsigned long>("count", "c", "Count value",
-                                                  false, 10UL);
-  auto* size =
-      parser.addArgument<unsigned long>("size", "s", "Size value", true);
+  auto* count =
+      parser.addArgument<uint64_t>("count", "c", "Count value", false, 10UL);
+  auto* size = parser.addArgument<uint64_t>("size", "s", "Size value", true);
 
   const char* argv[] = {"test_app", "--count", "42", "--size", "1000000"};
   int argc = sizeof(argv) / sizeof(argv[0]);
@@ -175,13 +177,13 @@ void test_unsigned_long_parsing() {
   assert(count->getValue() == 42UL);
   assert(size->getValue() == 1000000UL);
 
-  std::cout << "test_unsigned_long_parsing passed\n";
+  std::cout << "test_uint64_parsing passed\n";
 }
 
-void test_unsigned_long_negative_values() {
+void test_uint64_negative_values() {
   argsparser::Parser parser("test_app", "A test application");
 
-  auto* count = parser.addArgument<unsigned long>("count", "c", "Count value");
+  auto* count = parser.addArgument<uint64_t>("count", "c", "Count value");
 
   const char* argv[] = {"test_app", "--count", "-5"};
   int argc = sizeof(argv) / sizeof(argv[0]);
@@ -189,57 +191,57 @@ void test_unsigned_long_negative_values() {
   auto result = parser.parse(argc, const_cast<char**>(argv));
   assert(result == argsparser::ParseResult::INVALID_VALUE);
 
-  std::cout << "test_unsigned_long_negative_values passed\n";
+  std::cout << "test_uint64_negative_values passed\n";
 }
 
-void test_unsigned_long_overflow() {
+void test_uint64_overflow() {
   argsparser::Parser parser("test_app", "A test application");
 
   auto* largeNumber =
-      parser.addArgument<unsigned long>("large", "l", "A large number");
+      parser.addArgument<uint64_t>("large", "l", "A large number");
 
-  // Create a number larger than ULONG_MAX
+  // Create a number larger than UINT64_MAX
   std::string largeValue =
-      std::to_string(ULONG_MAX) + "0";  // Add a digit to make it larger
+      std::to_string(UINT64_MAX) + "0";  // Add a digit to make it larger
   const char* argv[] = {"test_app", "--large", largeValue.c_str()};
   int argc = sizeof(argv) / sizeof(argv[0]);
 
   auto result = parser.parse(argc, const_cast<char**>(argv));
   assert(result == argsparser::ParseResult::INVALID_VALUE);
 
-  std::cout << "test_unsigned_long_overflow passed\n";
+  std::cout << "test_uint64_overflow passed\n";
 }
 
-void test_unsigned_long_max() {
+void test_uint64_max() {
   argsparser::Parser parser("test_app", "A test application");
 
-  auto* maxNumber = parser.addArgument<unsigned long>(
-      "max", "m", "Maximum unsigned long value");
+  auto* maxNumber =
+      parser.addArgument<uint64_t>("max", "m", "Maximum uint64_t value");
 
-  // Test with ULONG_MAX, which should work
-  std::string maxValue = std::to_string(ULONG_MAX);
+  // Test with UINT64_MAX, which should work
+  std::string maxValue = std::to_string(UINT64_MAX);
   const char* argv[] = {"test_app", "--max", maxValue.c_str()};
   int argc = sizeof(argv) / sizeof(argv[0]);
 
   auto result = parser.parse(argc, const_cast<char**>(argv));
   assert(result == argsparser::ParseResult::SUCCESS);
-  assert(maxNumber->getValue() == ULONG_MAX);
+  assert(maxNumber->getValue() == UINT64_MAX);
 
-  std::cout << "test_unsigned_long_max passed\n";
+  std::cout << "test_uint64_max passed\n";
 }
 
 void test_integer_types_validators() {
   argsparser::Parser parser("test_app", "A test application");
 
   auto* positive =
-      parser.addArgument<unsigned int>("positive", "p", "Positive value");
-  auto* even = parser.addArgument<long>("even", "e", "Even value");
-  auto* large = parser.addArgument<unsigned long>("large", "l", "Large value");
+      parser.addArgument<uint32_t>("positive", "p", "Positive value");
+  auto* even = parser.addArgument<int64_t>("even", "e", "Even value");
+  auto* large = parser.addArgument<uint64_t>("large", "l", "Large value");
 
   // Set validators
-  positive->setValidator([](unsigned int value) { return value > 0; });
-  even->setValidator([](long value) { return value % 2 == 0; });
-  large->setValidator([](unsigned long value) { return value > 1000000UL; });
+  positive->setValidator([](uint32_t value) { return value > 0; });
+  even->setValidator([](int64_t value) { return value % 2 == 0; });
+  large->setValidator([](uint64_t value) { return value > 1000000UL; });
 
   const char* argv[] = {"test_app", "--positive", "5",      "--even",
                         "42",       "--large",    "2000000"};
@@ -259,8 +261,8 @@ void test_integer_types_validator_failures() {
   argsparser::Parser parser("test_app", "A test application");
 
   auto* positive =
-      parser.addArgument<unsigned int>("positive", "p", "Positive value");
-  positive->setValidator([](unsigned int value) { return value > 0; });
+      parser.addArgument<uint32_t>("positive", "p", "Positive value");
+  positive->setValidator([](uint32_t value) { return value > 0; });
 
   const char* argv[] = {"test_app", "--positive", "0"};
   int argc = sizeof(argv) / sizeof(argv[0]);
@@ -275,12 +277,13 @@ void test_mixed_integer_types() {
   argsparser::Parser parser("test_app", "A test application");
 
   auto* regular =
-      parser.addArgument<int>("regular", "r", "Regular int", false, 10);
-  auto* unsignedInt = parser.addArgument<unsigned int>(
-      "unsigned", "u", "Unsigned int", false, 20u);
-  auto* longInt = parser.addArgument<long>("long", "l", "Long int", false, 30L);
-  auto* unsignedLong = parser.addArgument<unsigned long>(
-      "ulong", "g", "Unsigned long", false, 40UL);
+      parser.addArgument<int32_t>("regular", "r", "Regular int", false, 10);
+  auto* unsignedInt =
+      parser.addArgument<uint32_t>("unsigned", "u", "Unsigned int", false, 20u);
+  auto* longInt =
+      parser.addArgument<int64_t>("long", "l", "Long int", false, 30L);
+  auto* unsignedLong =
+      parser.addArgument<uint64_t>("ulong", "g", "Unsigned long", false, 40UL);
 
   const char* argv[] = {"test_app", "--regular",  "-5",      "--unsigned", "15",
                         "--long",   "-123456789", "--ulong", "987654321"};
@@ -298,18 +301,18 @@ void test_mixed_integer_types() {
 }
 
 int main() {
-  test_unsigned_int_parsing();
-  test_unsigned_int_negative_values();
-  test_unsigned_int_overflow();
-  test_unsigned_int_max();
-  test_long_parsing();
-  test_long_overflow();
-  test_long_underflow();
-  test_long_max_min();
-  test_unsigned_long_parsing();
-  test_unsigned_long_negative_values();
-  test_unsigned_long_overflow();
-  test_unsigned_long_max();
+  test_uint32_parsing();
+  test_uint32_negative_values();
+  test_uint32_overflow();
+  test_uint32_max();
+  test_int64_parsing();
+  test_int64_overflow();
+  test_int64_underflow();
+  test_int64_max_min();
+  test_uint64_parsing();
+  test_uint64_negative_values();
+  test_uint64_overflow();
+  test_uint64_max();
   test_integer_types_validators();
   test_integer_types_validator_failures();
   test_mixed_integer_types();

--- a/tests/test_overflow.cpp
+++ b/tests/test_overflow.cpp
@@ -8,10 +8,12 @@
 void test_integer_overflow() {
   argsparser::Parser parser("test_app", "A test application");
 
-  auto* largeNumber = parser.addArgument<int>("large", "l", "A large number");
+  auto* largeNumber =
+      parser.addArgument<int32_t>("large", "l", "A large number");
 
-  // Test with a number that's too large for int
-  std::string largeValue = std::to_string(static_cast<long long>(INT_MAX) + 1);
+  // Test with a number that's too large for int32_t
+  std::string largeValue =
+      std::to_string(static_cast<long long>(INT32_MAX) + 1);
   const char* argv[] = {"test_app", "--large", largeValue.c_str()};
   int argc = sizeof(argv) / sizeof(argv[0]);
 
@@ -24,10 +26,12 @@ void test_integer_overflow() {
 void test_integer_underflow() {
   argsparser::Parser parser("test_app", "A test application");
 
-  auto* smallNumber = parser.addArgument<int>("small", "s", "A small number");
+  auto* smallNumber =
+      parser.addArgument<int32_t>("small", "s", "A small number");
 
-  // Test with a number that's too small for int
-  std::string smallValue = std::to_string(static_cast<long long>(INT_MIN) - 1);
+  // Test with a number that's too small for int32_t
+  std::string smallValue =
+      std::to_string(static_cast<long long>(INT32_MIN) - 1);
   const char* argv[] = {"test_app", "--small", smallValue.c_str()};
   int argc = sizeof(argv) / sizeof(argv[0]);
 
@@ -40,16 +44,17 @@ void test_integer_underflow() {
 void test_integer_max() {
   argsparser::Parser parser("test_app", "A test application");
 
-  auto* maxNumber = parser.addArgument<int>("max", "m", "Maximum int value");
+  auto* maxNumber =
+      parser.addArgument<int32_t>("max", "m", "Maximum int32_t value");
 
-  // Test with INT_MAX, which should work
-  std::string maxValue = std::to_string(INT_MAX);
+  // Test with INT32_MAX, which should work
+  std::string maxValue = std::to_string(INT32_MAX);
   const char* argv[] = {"test_app", "--max", maxValue.c_str()};
   int argc = sizeof(argv) / sizeof(argv[0]);
 
   auto result = parser.parse(argc, const_cast<char**>(argv));
   assert(result == argsparser::ParseResult::SUCCESS);
-  assert(maxNumber->getValue() == INT_MAX);
+  assert(maxNumber->getValue() == INT32_MAX);
 
   std::cout << "test_integer_max passed\n";
 }
@@ -57,16 +62,17 @@ void test_integer_max() {
 void test_integer_min() {
   argsparser::Parser parser("test_app", "A test application");
 
-  auto* minNumber = parser.addArgument<int>("min", "n", "Minimum int value");
+  auto* minNumber =
+      parser.addArgument<int32_t>("min", "n", "Minimum int32_t value");
 
-  // Test with INT_MIN, which should work
-  std::string minValue = std::to_string(INT_MIN);
+  // Test with INT32_MIN, which should work
+  std::string minValue = std::to_string(INT32_MIN);
   const char* argv[] = {"test_app", "--min", minValue.c_str()};
   int argc = sizeof(argv) / sizeof(argv[0]);
 
   auto result = parser.parse(argc, const_cast<char**>(argv));
   assert(result == argsparser::ParseResult::SUCCESS);
-  assert(minNumber->getValue() == INT_MIN);
+  assert(minNumber->getValue() == INT32_MIN);
 
   std::cout << "test_integer_min passed\n";
 }


### PR DESCRIPTION
Replace int, unsigned int, long, and unsigned long with fixed-width types\n  (int16_t, uint32_t, int32_t, uint64_t, int64_t)\n- Update examples and tests to use the new types\n- Update README.md to reflect the changes\n- Fix duplicate printHelp function definition in argsparser.hpp